### PR TITLE
Replace external mock services with in-repo httptest mocks

### DIFF
--- a/cli.bats
+++ b/cli.bats
@@ -1,19 +1,38 @@
 #!/usr/bin/env bats
 
-# this endpoint will return the same content as in testdata/bookmarks.json
-EXPORT_ENDPOINT="http://www.mocky.io/v2/5775832a0f0000e90997c48c/"
+# Build the local mock server once per file and start it in the background.
+# Tests reach it via $MOCK_URL.
+setup_file() {
+	export MOCK_BIN="$BATS_FILE_TMPDIR/mockserver"
+	go build -o "$MOCK_BIN" ./testdata/mockserver
 
-# simulates a successful delete via the pinboard API
-DELETE_OK_ENDPOINT="http://www.mocky.io/v2/579755b6260000dd1217facc/"
+	"$MOCK_BIN" > "$BATS_FILE_TMPDIR/mock_url" &
+	echo $! > "$BATS_FILE_TMPDIR/mock_pid"
 
-# simulates a failed delete via the pinboard API
-DELETE_FAIL_ENDPOINT="http://www.mocky.io/v2/579755d3260000dc1217facd/"
+	# Wait for the server to print its URL.
+	for _ in $(seq 1 50); do
+		[ -s "$BATS_FILE_TMPDIR/mock_url" ] && break
+		sleep 0.1
+	done
+
+	export MOCK_URL=$(cat "$BATS_FILE_TMPDIR/mock_url")
+	export EXPORT_ENDPOINT="$MOCK_URL/export/"
+	export DELETE_OK_ENDPOINT="$MOCK_URL/delete-ok/"
+	export DELETE_FAIL_ENDPOINT="$MOCK_URL/delete-fail/"
+	export DELAY_URL="$MOCK_URL/delay/3"
+}
+
+teardown_file() {
+	if [ -f "$BATS_FILE_TMPDIR/mock_pid" ]; then
+		kill "$(cat "$BATS_FILE_TMPDIR/mock_pid")" 2>/dev/null || true
+	fi
+}
 
 # this will prevent a token being accidentally read from your user's config
 setup() {
 	if [ -f ~/.pinboard-checker/pinboard-checker.yaml ]; then
 		mv ~/.pinboard-checker/pinboard-checker.yaml ~/.pinboard-checker/bak.pinboard-checker.yaml
-	fi 
+	fi
 }
 
 @test "check: Token argument is required" {
@@ -26,10 +45,10 @@ setup() {
 	# Note: The `time` command outputs on stderr, won't be captured by bats generally.
 	# That's why we have to redirect the output into a variable to match its content.
 
-	output=$(time (echo 'http://httpbin.org/delay/3' | ./pinboard-checker check -i - --inputFormat=txt --timeout=1s 2>/dev/null 1>&2) 2>&1)
-	
+	output=$(time (echo "$DELAY_URL" | ./pinboard-checker check -i - --inputFormat=txt --timeout=1s 2>/dev/null 1>&2) 2>&1)
+
 	# this checks that the time taken is 1 second and a few miliseconds
-	[[ $output =~ real[[:space:]]0m1.[0-9]+s ]]	
+	[[ $output =~ real[[:space:]]0m1.[0-9]+s ]]
 }
 
 @test "delete: Token argument is required" {
@@ -68,5 +87,5 @@ setup() {
 teardown() {
 	if [ -f ~/.pinboard-checker/bak.pinboard-checker.yaml ]; then
 		mv ~/.pinboard-checker/bak.pinboard-checker.yaml ~/.pinboard-checker/pinboard-checker.yaml
-	fi 
+	fi
 }

--- a/pinboard/checker_test.go
+++ b/pinboard/checker_test.go
@@ -2,6 +2,9 @@ package pinboard
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -14,8 +17,28 @@ func makeChecker() *Checker {
 	}
 }
 
+// statusServer returns a handler that reads the desired status code from
+// paths shaped like "/status/NNN" and treats "/" as 200 OK.
+func statusServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/status/") {
+			code, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/status/"))
+			if err != nil {
+				http.Error(w, "bad status path", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(code)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
 func TestCheckGoodHttpStatus(t *testing.T) {
-	bookmark := Bookmark{Href: "http://httpbin.org/html"}
+	server := statusServer()
+	defer server.Close()
+
+	bookmark := Bookmark{Href: server.URL + "/status/200"}
 	checker := makeChecker()
 	success, code, _ := checker.check(bookmark)
 	if !success {
@@ -24,7 +47,10 @@ func TestCheckGoodHttpStatus(t *testing.T) {
 }
 
 func TestCheckBadHttpStatus(t *testing.T) {
-	bookmark := Bookmark{Href: "http://httpbin.org/status/412"}
+	server := statusServer()
+	defer server.Close()
+
+	bookmark := Bookmark{Href: server.URL + "/status/412"}
 	checker := makeChecker()
 	success, code, _ := checker.check(bookmark)
 	if success {
@@ -33,12 +59,15 @@ func TestCheckBadHttpStatus(t *testing.T) {
 }
 
 func TestSimpleReporterShowingAFailure(t *testing.T) {
+	server := statusServer()
+	defer server.Close()
+
 	verbose := false
 	var buffer bytes.Buffer
 
 	bookmarks := []Bookmark{
-		Bookmark{Href: "http://httpbin.org/status/404"},
-		Bookmark{Href: "http://httpbin.org/status/200"},
+		{Href: server.URL + "/status/404"},
+		{Href: server.URL + "/status/200"},
 	}
 	checker := makeChecker()
 	checker.Reporter = NewSimpleFailureReporter(verbose, true, &buffer)
@@ -52,11 +81,14 @@ func TestSimpleReporterShowingAFailure(t *testing.T) {
 }
 
 func TestSimpleReporterShowingASucessInVerboseMode(t *testing.T) {
+	server := statusServer()
+	defer server.Close()
+
 	verbose := true
 	var buffer bytes.Buffer
 
 	bookmarks := []Bookmark{
-		Bookmark{Href: "http://httpbin.org/status/200"},
+		{Href: server.URL + "/status/200"},
 	}
 	checker := makeChecker()
 	checker.Reporter = NewSimpleFailureReporter(verbose, true, &buffer)
@@ -70,12 +102,15 @@ func TestSimpleReporterShowingASucessInVerboseMode(t *testing.T) {
 }
 
 func TestJSONReporterShowingAFailure(t *testing.T) {
+	server := statusServer()
+	defer server.Close()
+
 	verbose := false
 	var buffer bytes.Buffer
 
 	bookmarks := []Bookmark{
-		Bookmark{Href: "http://httpbin.org/status/404"},
-		Bookmark{Href: "http://httpbin.org/status/200"},
+		{Href: server.URL + "/status/404"},
+		{Href: server.URL + "/status/200"},
 	}
 
 	reporter := NewJSONReporter(verbose, &buffer)
@@ -103,12 +138,15 @@ func TestJSONReporterShowingAFailure(t *testing.T) {
 }
 
 func TestJSONReporterShowingSuccessInVerboseMode(t *testing.T) {
+	server := statusServer()
+	defer server.Close()
+
 	verbose := true
 	var buffer bytes.Buffer
 
 	bookmarks := []Bookmark{
-		Bookmark{Href: "http://httpbin.org/status/404"},
-		Bookmark{Href: "http://httpbin.org/status/200"},
+		{Href: server.URL + "/status/404"},
+		{Href: server.URL + "/status/200"},
 	}
 
 	reporter := NewJSONReporter(verbose, &buffer)

--- a/pinboard/pinboard_test.go
+++ b/pinboard/pinboard_test.go
@@ -82,8 +82,8 @@ func TestWriteJSON(t *testing.T) {
 
 func TestTxtInputFormatForReadingFromFile(t *testing.T) {
 	inputFile := strings.NewReader(`
-		http://httpbin.org/status/404
-		http://httpbin.org/status/404
+		http://example.com/a
+		http://example.com/b
 	`)
 	bookmarks := GetBookmarksFromFile(inputFile, TXT)
 	if len(bookmarks) != 2 {

--- a/testdata/mockserver/main.go
+++ b/testdata/mockserver/main.go
@@ -1,0 +1,82 @@
+// Mock server used by cli.bats integration tests.
+//
+// It serves three pinboard-API-shaped endpoints (export, delete-ok,
+// delete-fail) and a /delay/<seconds> handler used to exercise the
+// check command's --timeout flag. The server prints its base URL on
+// stdout and runs until it receives SIGINT/SIGTERM.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const bookmarksJSON = `[
+  {
+    "href": "https://blog.bracelab.com/achieving-perfect-ssl-labs-score-with-go",
+    "description": "Achieving a Perfect SSL Labs Score with Go",
+    "extended": "",
+    "meta": "a9138eea3d5ea2cf7dedf29c70a9b786",
+    "hash": "811a463298eeb77d7e3ddb2119d4b159",
+    "time": "2016-05-29T10:16:11Z",
+    "shared": "yes",
+    "toread": "no",
+    "tags": "golang http ssl configuration"
+  },
+  {
+    "href": "https://github.com/xenolf/lego",
+    "description": "xenolf/lego: Let's Encrypt client and ACME library written in Go",
+    "extended": "",
+    "meta": "4ad7b349071a3df9b96b5dabe4dddf04",
+    "hash": "6f02cfface77e59cbce7788d44095fcc",
+    "time": "2016-05-29T10:14:53Z",
+    "shared": "no",
+    "toread": "yes",
+    "tags": "golang encryption library tool ssl certificates"
+  }
+]`
+
+func canned(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, body)
+	}
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	// Endpoints used by the bats tests. Each one is a base URL the binary
+	// will append paths like /v1/posts/all or /v1/posts/delete to; the
+	// canned response is returned regardless of the suffix.
+	mux.Handle("/export/", canned(bookmarksJSON))
+	mux.Handle("/delete-ok/", canned(`{"result_code":"done"}`))
+	mux.Handle("/delete-fail/", canned(`{"result_code":"item not found"}`))
+
+	// /delay/<seconds> sleeps and returns 200, used by the timeout test.
+	mux.HandleFunc("/delay/", func(w http.ResponseWriter, r *http.Request) {
+		secs := strings.TrimPrefix(r.URL.Path, "/delay/")
+		d, err := time.ParseDuration(secs + "s")
+		if err != nil {
+			http.Error(w, "bad delay", http.StatusBadRequest)
+			return
+		}
+		time.Sleep(d)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	fmt.Println(server.URL)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+}


### PR DESCRIPTION
## Summary

Replace the two external services that the test suites depended on with local mocks, so the tests no longer need live network and aren't at the mercy of services that have gone dormant or started rate-limiting.

### Why

- `pinboard/checker_test.go` hit live `http://httpbin.org/status/...` URLs. httpbin.org now intermittently returns 403 instead of the requested status codes, causing 4 tests to fail spuriously.
- `cli.bats` hit `mocky.io` URLs created in 2018 (export, delete-ok, delete-fail) and `httpbin.org/delay/3` (timeout test). The mocky endpoints now return non-JSON, breaking the export and delete tests.

### What

- **`pinboard/checker_test.go`**: Each test spins up an `httptest.NewServer` whose handler reads the desired status code from the path (`/status/NNN`).
- **`pinboard/pinboard_test.go`**: The text-input parser fixture also referenced `httpbin.org` URLs purely as strings (no HTTP); swap them for `example.com` so the intent is clear.
- **`testdata/mockserver/main.go`** (new): A small standalone server that serves the three pinboard-shaped canned responses (export, delete-ok, delete-fail) and a `/delay/<seconds>` handler. Lives under `testdata/` so `go list ./...` and `go build ./...` ignore it.
- **`cli.bats`**: Uses `setup_file` to build and start the mock server once, exposes its URL via env vars (`EXPORT_ENDPOINT`, `DELETE_OK_ENDPOINT`, `DELETE_FAIL_ENDPOINT`, `DELAY_URL`), and tears it down in `teardown_file`.

### Test plan

- [x] `go test ./...` passes locally with no live network
- [x] `bats cli.bats` passes locally — all 7 tests green (was 4/7 before)
- [x] Codecov upload still works on CI
- [x] Both Go matrix legs (`stable`, `oldstable`) stay green on Actions

Closes the test-brittleness follow-up from #2.