### PR TITLE
Bump CI actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
@@ -21,7 +21,7 @@ jobs:
         run: ./test_coverage.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.txt
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Address the Node.js 20 deprecation warning that appears at the end of every CI run. GitHub Actions is forcing Node 24 on June 2, 2026 and removing Node 20 from runners on September 16, 2026.

The deprecation warning currently lists three actions still on Node 20:
- `actions/checkout@v4`
- `actions/setup-go@v5`
- `actions/github-script@<sha>` (transitive — pinned inside `codecov/codecov-action@v5`)

Bump each major version that runs on Node:

| Action | Old | New | Node 24 added in |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | v5 |
| `actions/setup-go` | v5 | v6 | v6 |
| `codecov/codecov-action` | v5 | v6 | v6 |

The codecov v6 inputs (`files`, `fail_ci_if_error`) are unchanged from v5, so this is a drop-in version bump. Bumping codecov to v6 also pulls in a Node 24-compatible `actions/github-script`, which is what surfaces the third entry in the deprecation list.

## Test plan

- [x] CI passes on the PR (build + tests still green — 44s, consistent with prior real-test runs)
- [x] Node 20 deprecation warning is gone from the run summary

Closes the deprecation follow-up noted on PR #3.