### PR TITLE
Pass CODECOV_TOKEN to the Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           files: ./coverage.txt
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Master uploads to Codecov currently fail with `Token required because branch is protected` — Codecov treats the default branch as protected and rejects tokenless uploads from it. Pass the `CODECOV_TOKEN` repo secret to authenticate.

PRs from forks can't read repo secrets, so the token expression resolves to an empty string in that case. The codecov-action treats an empty token as a tokenless upload, which is still accepted on feature/PR branches.

## Test plan

- [x] CI passes on the PR
- [ ] On the next master run, the Codecov upload step does not log `Token required because branch is protected`
- [ ] Codecov dashboard shows updated coverage after the master run

---
_Generated by [Claude Code](https://claude.ai/code/session_01627JhTxPvsAv5ppzDoXYPu)_