### PR TITLE
Code review fixes: bugs, deprecations, and style cleanup

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -93,7 +93,11 @@ var checkCmd = &cobra.Command{
 				defer opened.Close()
 				file = opened
 			}
-			bookmarks = pinboard.GetBookmarksFromFile(file, inputFormat)
+			var parseErr error
+			bookmarks, parseErr = pinboard.GetBookmarksFromFile(file, inputFormat)
+			if parseErr != nil {
+				logger.Fatalf("Could not parse input file: %s", parseErr)
+			}
 		} else {
 			token := validateToken()
 			endpoint := viper.GetString("endpoint")

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -86,16 +86,28 @@ var checkCmd = &cobra.Command{
 			if inputFile == "-" {
 				file = os.Stdin
 			} else {
-				file, _ = os.Open(inputFile)
+				opened, err := os.Open(inputFile)
+				if err != nil {
+					logger.Fatalf("Could not open input file %s: %s", inputFile, err)
+				}
+				defer opened.Close()
+				file = opened
 			}
 			bookmarks = pinboard.GetBookmarksFromFile(file, inputFormat)
 		} else {
 			token := validateToken()
 			endpoint := viper.GetString("endpoint")
-			endpointUrl, _ := url.Parse(endpoint)
+			endpointUrl, err := url.Parse(endpoint)
+			if err != nil {
+				logger.Fatalf("Invalid endpoint URL %s: %s", endpoint, err)
+			}
 
 			client := pinboard.NewClient(token, endpointUrl)
-			bookmarks, _ = client.GetAllBookmarks()
+			var downloadErr error
+			bookmarks, downloadErr = client.GetAllBookmarks()
+			if downloadErr != nil {
+				logger.Fatalf("Could not download bookmarks: %s", downloadErr)
+			}
 		}
 
 		var tlsConfig *tls.Config

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -64,18 +64,17 @@ To read from stdout, use '-' as file name.`,
 	},
 }
 
-func deleteAll(token string, endpoint *url.URL, bookmarks []pinboard.Bookmark) (err error) {
+func deleteAll(token string, endpoint *url.URL, bookmarks []pinboard.Bookmark) error {
 	client := pinboard.NewClient(token, endpoint)
-	var errorDuringDelete bool = false
+	var errorDuringDelete bool
 	for _, bookmark := range bookmarks {
-		delErr := client.DeleteBookmark(bookmark)
-		if delErr != nil {
+		if delErr := client.DeleteBookmark(bookmark); delErr != nil {
 			logger.Warnf("Error trying to delete %s: %s", bookmark.Href, delErr)
 			errorDuringDelete = true
 		}
 	}
 	if errorDuringDelete {
-		err = errors.New("Encountered at least one error when trying to delete bookmarks")
+		return errors.New("encountered at least one error when trying to delete bookmarks")
 	}
-	return
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func init() {
 func validateToken() string {
 	token := viper.GetString("token")
 	if len(token) == 0 {
-		logger.Fatal("Token flag is mandatory for export command")
+		logger.Fatal("Token flag is mandatory")
 	}
 	return token
 }

--- a/pinboard/checker.go
+++ b/pinboard/checker.go
@@ -3,7 +3,6 @@ package pinboard
 import (
 	"crypto/tls"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"sync"
@@ -19,9 +18,9 @@ type LookupFailure struct {
 }
 
 type Reporter interface {
-	onFailure(failure LookupFailure)
-	onSuccess(bookmark Bookmark)
-	onEnd()
+	OnFailure(failure LookupFailure)
+	OnSuccess(bookmark Bookmark)
+	OnEnd()
 }
 
 var DefaultTimeout = 10 * time.Second
@@ -86,7 +85,7 @@ func (checker *Checker) requestUrl(method string, url string) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	io.Copy(ioutil.Discard, response.Body)
+	io.Copy(io.Discard, response.Body)
 	response.Body.Close()
 	return response, nil
 }
@@ -99,10 +98,10 @@ func (checker *Checker) worker(id int, checkJobs <-chan Bookmark, workgroup *syn
 		logger.Debugf("Worker %02d: Processing job for url %s", id, bookmark.Href)
 		valid, code, err := checker.check(bookmark)
 		if !valid {
-			checker.Reporter.onFailure(LookupFailure{bookmark, code, err})
+			checker.Reporter.OnFailure(LookupFailure{bookmark, code, err})
 			logger.Debugf("Worker %02d: ERROR: %s %d %s", id, bookmark.Href, code, err)
 		} else {
-			checker.Reporter.onSuccess(bookmark)
+			checker.Reporter.OnSuccess(bookmark)
 			logger.Debugf("Worker %02d: Success for %s\n", id, bookmark.Href)
 		}
 	}
@@ -127,5 +126,5 @@ func (checker *Checker) Run(bookmarks []Bookmark) {
 
 	close(jobs)
 	workgroup.Wait()
-	checker.Reporter.onEnd()
+	checker.Reporter.OnEnd()
 }

--- a/pinboard/checker_test.go
+++ b/pinboard/checker_test.go
@@ -125,7 +125,10 @@ func TestJSONReporterShowingAFailure(t *testing.T) {
 		t.Errorf("One failure should have been reported, %d found", failureCount)
 	}
 
-	failedBookmarks := ParseJSON(bytes.NewReader(buffer.Bytes()))
+	failedBookmarks, err := ParseJSON(bytes.NewReader(buffer.Bytes()))
+	if err != nil {
+		t.Fatalf("Unexpected error parsing JSON output: %s", err)
+	}
 	failedBookmarksCount := len(failedBookmarks)
 	if failedBookmarksCount != 1 {
 		t.Errorf("Expected one failed bookmark to be present in generated JSON, %d found", failedBookmarksCount)
@@ -159,7 +162,10 @@ func TestJSONReporterShowingSuccessInVerboseMode(t *testing.T) {
 		t.Errorf("One failure should have been reported, %d found", successCount)
 	}
 
-	failedBookmarks := ParseJSON(bytes.NewReader(buffer.Bytes()))
+	failedBookmarks, err := ParseJSON(bytes.NewReader(buffer.Bytes()))
+	if err != nil {
+		t.Fatalf("Unexpected error parsing JSON output: %s", err)
+	}
 	failedBookmarksCount := len(failedBookmarks)
 	if failedBookmarksCount != 2 {
 		t.Errorf("Expected two bookmarks to be present in generated JSON, %d found", failedBookmarksCount)

--- a/pinboard/pinboard.go
+++ b/pinboard/pinboard.go
@@ -3,7 +3,6 @@ package pinboard
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,7 +39,7 @@ func FormatFromString(value string) (Format, error) {
 	case "txt":
 		return TXT, nil
 	}
-	return 0, errors.New(fmt.Sprintf("%s is not a valid format value", value))
+	return 0, fmt.Errorf("%s is not a valid format value", value)
 }
 
 type PinboardBoolean bool
@@ -58,9 +57,8 @@ func (p *PinboardBoolean) UnmarshalJSON(data []byte) error {
 func (p *PinboardBoolean) MarshalJSON() ([]byte, error) {
 	if *p {
 		return json.Marshal("yes")
-	} else {
-		return json.Marshal("no")
 	}
+	return json.Marshal("no")
 }
 
 type PinboardTags []string
@@ -209,11 +207,11 @@ func (client *Client) DeleteBookmark(bookmark Bookmark) (err error) {
 	}
 
 	if result.Code == "item not found" {
-		return errors.New(fmt.Sprintf("%s was not found in pinboard", bookmark.Href))
+		return fmt.Errorf("%s was not found in pinboard", bookmark.Href)
 	}
 
 	if result.Code != "done" {
-		return errors.New(fmt.Sprintf("unexpected result code '%s'", result.Code))
+		return fmt.Errorf("unexpected result code '%s'", result.Code)
 	}
 
 	return err

--- a/pinboard/pinboard.go
+++ b/pinboard/pinboard.go
@@ -158,22 +158,27 @@ func (client *Client) buildDeleteEndpoint(rawUrl string) string {
 
 func (client *Client) DownloadBookmarks() (io.ReadCloser, error) {
 	req, err := http.NewRequest("GET", client.buildDownloadEndpoint(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	httpClient := &http.Client{}
 	response, err := httpClient.Do(req)
-
 	if err != nil {
 		logger.Debugf("Error %s", err)
 		return nil, err
 	}
 
-	return response.Body, err
+	return response.Body, nil
 }
 
 func (client *Client) GetAllBookmarks() ([]Bookmark, error) {
 	readCloser, err := client.DownloadBookmarks()
+	if err != nil {
+		return nil, err
+	}
 	defer readCloser.Close()
-	return ParseJSON(readCloser), err
+	return ParseJSON(readCloser), nil
 }
 
 func (client *Client) DeleteBookmark(bookmark Bookmark) (err error) {

--- a/pinboard/pinboard.go
+++ b/pinboard/pinboard.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,10 +100,12 @@ type Bookmark struct {
 	FailureInfo FailureInfo     `json:"failure,omitempty"`
 }
 
-func ParseJSON(input io.Reader) []Bookmark {
+func ParseJSON(input io.Reader) ([]Bookmark, error) {
 	var bookmarks []Bookmark
-	json.NewDecoder(input).Decode(&bookmarks)
-	return bookmarks
+	if err := json.NewDecoder(input).Decode(&bookmarks); err != nil {
+		return nil, err
+	}
+	return bookmarks, nil
 }
 
 func ParseText(input io.Reader) []Bookmark {
@@ -178,7 +179,7 @@ func (client *Client) GetAllBookmarks() ([]Bookmark, error) {
 		return nil, err
 	}
 	defer readCloser.Close()
-	return ParseJSON(readCloser), nil
+	return ParseJSON(readCloser)
 }
 
 func (client *Client) DeleteBookmark(bookmark Bookmark) (err error) {
@@ -192,7 +193,7 @@ func (client *Client) DeleteBookmark(bookmark Bookmark) (err error) {
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}
@@ -222,13 +223,12 @@ func NewClient(token string, endpoint *url.URL) *Client {
 	return &Client{Token: token, Endpoint: endpoint}
 }
 
-func GetBookmarksFromFile(reader io.Reader, format Format) []Bookmark {
-	var bookmarks []Bookmark
+func GetBookmarksFromFile(reader io.Reader, format Format) ([]Bookmark, error) {
 	switch format {
 	case TXT:
-		bookmarks = ParseText(reader)
+		return ParseText(reader), nil
 	case JSON:
-		bookmarks = ParseJSON(reader)
+		return ParseJSON(reader)
 	}
-	return bookmarks
+	return nil, nil
 }

--- a/pinboard/pinboard_test.go
+++ b/pinboard/pinboard_test.go
@@ -49,7 +49,10 @@ func TestParseJSON(t *testing.T) {
 	file, _ := os.Open("testdata/bookmarks.json")
 	defer file.Close()
 
-	bookmarks := ParseJSON(file)
+	bookmarks, err := ParseJSON(file)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 
 	if len(bookmarks) != 2 {
 		t.Errorf("Expected 2 bookmark objects to be parsed from JSON, got %d", len(bookmarks))
@@ -61,11 +64,21 @@ func TestParseJSON(t *testing.T) {
 	}
 }
 
+func TestParseJSONReturnsErrorOnBadInput(t *testing.T) {
+	_, err := ParseJSON(strings.NewReader("not json"))
+	if err == nil {
+		t.Error("Expected an error for malformed JSON input")
+	}
+}
+
 func TestWriteJSON(t *testing.T) {
 	file, _ := os.Open("testdata/bookmarks.json")
 	defer file.Close()
 
-	bookmarks := ParseJSON(file)
+	bookmarks, err := ParseJSON(file)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 
 	var b bytes.Buffer
 	buf := bufio.NewWriter(&b)
@@ -73,7 +86,10 @@ func TestWriteJSON(t *testing.T) {
 	writeJSON(bookmarks, buf)
 	buf.Flush()
 
-	deserialized := ParseJSON(bufio.NewReader(&b))
+	deserialized, err := ParseJSON(bufio.NewReader(&b))
+	if err != nil {
+		t.Fatalf("Unexpected error deserializing: %s", err)
+	}
 
 	if !reflect.DeepEqual(bookmarks, deserialized) {
 		t.Errorf("Deserialization did not work")
@@ -85,7 +101,10 @@ func TestTxtInputFormatForReadingFromFile(t *testing.T) {
 		http://example.com/a
 		http://example.com/b
 	`)
-	bookmarks := GetBookmarksFromFile(inputFile, TXT)
+	bookmarks, err := GetBookmarksFromFile(inputFile, TXT)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 	if len(bookmarks) != 2 {
 		t.Errorf("Text links were not parsed as bookmarks for input")
 	}
@@ -95,7 +114,10 @@ func TestJSONInputFormatForReadingFromFile(t *testing.T) {
 	file, _ := os.Open("testdata/bookmarks.json")
 	defer file.Close()
 
-	bookmarks := GetBookmarksFromFile(file, JSON)
+	bookmarks, err := GetBookmarksFromFile(file, JSON)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 	if len(bookmarks) != 2 {
 		t.Errorf("JSON links were not parsed as bookmarks for input")
 	}

--- a/pinboard/reporter.go
+++ b/pinboard/reporter.go
@@ -40,13 +40,13 @@ func (r SimpleFailureReporter) constructErrorMessage(failure LookupFailure) stri
 	return fmt.Sprintf("Other: %s", errorParts[len(errorParts)-1])
 }
 
-func (r SimpleFailureReporter) onFailure(failure LookupFailure) {
+func (r SimpleFailureReporter) OnFailure(failure LookupFailure) {
 	for _, writer := range r.writers {
 		fmt.Fprintf(writer, "%s%s %s\n", r.makeFailurePrefix(), failure.Bookmark.Href, r.constructErrorMessage(failure))
 	}
 }
 
-func (r SimpleFailureReporter) onSuccess(bookmark Bookmark) {
+func (r SimpleFailureReporter) OnSuccess(bookmark Bookmark) {
 	if r.verbose {
 		for _, writer := range r.writers {
 			fmt.Fprintf(writer, "%s%s\n", r.makeSuccessPrefix(), bookmark.Href)
@@ -54,7 +54,7 @@ func (r SimpleFailureReporter) onSuccess(bookmark Bookmark) {
 	}
 }
 
-func (r SimpleFailureReporter) onEnd() {
+func (r SimpleFailureReporter) OnEnd() {
 	// does nothing
 }
 
@@ -77,15 +77,15 @@ type JSONReporter struct {
 	successes []Bookmark
 }
 
-func (r *JSONReporter) onFailure(failure LookupFailure) {
+func (r *JSONReporter) OnFailure(failure LookupFailure) {
 	r.failures = append(r.failures, failure)
 }
 
-func (r *JSONReporter) onSuccess(bookmark Bookmark) {
+func (r *JSONReporter) OnSuccess(bookmark Bookmark) {
 	r.successes = append(r.successes, bookmark)
 }
 
-func (r *JSONReporter) onEnd() {
+func (r *JSONReporter) OnEnd() {
 	var failed []Bookmark
 	checkedAt := time.Now()
 


### PR DESCRIPTION
Three rounds of fixes following a thorough code review of the codebase.

## Bug fixes
- **`GetAllBookmarks` nil dereference** (`pinboard/pinboard.go`) — `defer readCloser.Close()` ran before the error check, panicking on any download error. Now returns early when `DownloadBookmarks` fails.
- **`DownloadBookmarks` shadowed error** — the error from `http.NewRequest` was overwritten before being checked, allowing a nil request to be passed to `httpClient.Do`. Fixed.
- **Silently dropped errors in `cmd/check.go`** — `os.Open`, `url.Parse`, and `GetAllBookmarks` errors were discarded with `_`. They now fatal with a clear message.

## Medium-severity fixes
- **Deprecated `io/ioutil`** — replaced `ioutil.ReadAll` and `ioutil.Discard` with their `io` equivalents.
- **`Reporter` interface had unexported methods** — renamed `onFailure`/`onSuccess`/`onEnd` to `OnFailure`/`OnSuccess`/`OnEnd` so implementations outside the package can satisfy it.
- **`ParseJSON` swallowed decode errors** — now returns `([]Bookmark, error)`. `GetBookmarksFromFile` was updated to propagate. Added `TestParseJSONReturnsErrorOnBadInput`.

## Minor cleanup
- `errors.New(fmt.Sprintf(...))` → `fmt.Errorf` (3 sites).
- Removed unnecessary `else` after `return` in `PinboardBoolean.MarshalJSON`.
- `var errorDuringDelete bool = false` → `var errorDuringDelete bool`.
- `validateToken` no longer hardcodes "for export command" — `check` and `delete` use it too.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes (existing + new `TestParseJSONReturnsErrorOnBadInput`)
- [x] CI green on this branch
- [x] `cli.bats` integration tests pass locally